### PR TITLE
Linux build changes

### DIFF
--- a/oom/__init__.py
+++ b/oom/__init__.py
@@ -8,9 +8,9 @@
 #
 # ////////////////////////////////////////////////////////////////////
 #
-# all of the functions of the OOM Northbound API are in oomlib
+# all of the functions of the OOM Northbound API are in oom
 # import all of them to expose the OOM Northbound API
 # other modules in the OOM package implement the decode features
 #
 
-from .oomlib import *
+from .oom import *

--- a/oom/addonsample.py
+++ b/oom/addonsample.py
@@ -1,0 +1,115 @@
+"""
+addonsample.py - demonstrate how to add capability to OOM
+
+This file (or your own addon file) must be placed in the './addons' in
+the directory where the OOM package has been installed.  If ./addons
+does not exist, simply create it, then add your file there.
+
+When OOM is started (when oomlib.py is initialized), the list of files
+matching './addons/*.py' and './addons/*.pyc' is created (if both
+suffixes exist for the same module, the import library picks one)
+The 'add_features' function from each module is added to a list.
+
+Whenever oom_get_portlist() is called, OOM builds a class of type Port
+for each port in the switch.  As part of building each Port, OOM
+will call each of the 'add_features' functions in the list, as
+add_features(port).  The port will be correctly built, including its
+port_type.  The port is readable, so add_features() can read any keys
+or directly read any EEPROM location to determine whether the
+specific features being added would apply to that module.
+
+At the least, add_features() should verify that the port_type
+is appropriate for the features being added.  Other likely
+screens might include keys like VENDOR_NAME, VENDOR_PN, VENDOR_REV,
+REV_COMPLIANCE, etc.
+
+NOTE:  A possible future use of addons is to provide different
+or added keys to match different spec versions with different
+modules.  The base OOM keys might match 'rev 3' of 'the spec'.  An
+addon could add additional keys defined in 'rev 4'.  That addon could
+check the REV_COMPLIANCE key of the module to decide whether or
+not to add the additional keys.  This would allow one release of
+OOM to support modules with different spec revs, even in the
+same switch at the same time.
+
+In this sample file we will add two keys to a QSFP+ module.
+   COOLED_TRANSMITTER is one bit, indicating whether the transmitter
+   is cooled (=1) or uncooled (=0)
+   TUNABLE_TRANSMITTER is one bit, indicating whether the transmitter
+   is tunable (=1) or not tunable (=0)
+These bits are described in the Table 6-19 of SFF-8636, rev 2.6.  They
+are available from OOM in the DEVICE_TECH key, but are not decoded.
+They are in the EEPROM at address 0Ah, page 0, byte 147, bits 2 and 0.
+This addon file will add these keys to OOM.
+
+We will also add a new function TRANSMITTER_TECH that returns both keys
+
+We will also add write keys to modify our new keys.  These write keys
+will actually fail because that is not a writable field in the EEPROM,
+but it will demonstrate the method of adding a write key.
+
+To activate this file (add these keys to QSFP+ modules), simply copy
+the file into the addons directory: 'cp addonsample.py ./addons/'
+The additional keys will be available to all subsequent users of OOM
+To deactivate, remove the file: 'rm ./addons/addonsample.py'
+
+See qsfp_plus.py for a rich list of keys and their extractor functions
+See decode.py for the exhaustive list of extractor functions in OOM
+Note: The implementation requires that extractor functions reside in
+decode.py.
+"""
+
+# Create dictionaries of new keys to be inserted as necessary
+# into port.mmap, port.fmap, port.wmap
+#
+# mmap keys begin with the user-visible key name,
+# followed by:
+#   the routine (from decode.py) used to extract the key
+#   the location of the data: address, page, offset(byte), length (bytes)
+# Note that writable keys take their location from port.mmap
+# so there can be no keys in new_wmap_keys that are not also
+# in new_mmap_keys
+#
+
+new_mmap_keys = {
+    'COOLED_TRANSMITTER':  ('get_bit2', 0xA0, 0, 147, 1),
+    'TUNABLE_TRANSMITTER': ('get_bit0', 0xA0, 0, 147, 1),
+    }
+
+# A new function key to group these together
+# call as ttech = oom_get_memory(port, 'TRANSMITTER_TECH')
+new_fmap_keys = {
+    'TRANSMITTER_TECH': ('COOLED_TRANSMITTER',
+                         'TUNABLE_TRANSMITTER',
+                         )
+                }
+
+
+# the writable keys to match
+# remember, writable keys use the mmap key value for the location
+# to write the data to.  Every wmap key requires a matching mmap key.
+# note, this location in QSFP+ is not actually writable, so actually
+# trying to use these keys
+#    - eg oom_set_keyvalue(port, 'COOLED_TRANSMITTER', 1)
+# would fail, probably silently
+new_wmap_keys = {
+    'COOLED_TRANSMITTER': 'set_bit2',
+    'TUNABLE_TRANSMITTER': 'set_bit0'
+    }
+
+
+# add the new keys to mmap, fmap, wmap for QSFP+ ports
+# note 'add_features(port)' is an architected API, you can't change
+# the name and expect to get called, you will get called with a port
+# You CAN add additional code here, and additional functions.  Call
+# them from add_features() to get executed once for each port, each
+# time oom_get_portlist() is invoked.
+def add_features(port):
+    QSFP_PLUS = 0xD
+
+    # only add these keys to QSFP+ ports (add other filters here)
+    if port.port_type != QSFP_PLUS:
+        return
+    port.mmap.update(new_mmap_keys)
+    port.fmap.update(new_fmap_keys)
+    port.wmap.update(new_wmap_keys)

--- a/oom/addonsample.py
+++ b/oom/addonsample.py
@@ -23,6 +23,14 @@ is appropriate for the features being added.  Other likely
 screens might include keys like VENDOR_NAME, VENDOR_PN, VENDOR_REV,
 REV_COMPLIANCE, etc.
 
+There is no architectural limit on the number of addon files that
+can be added to the addons directory.
+Multiple addons can be applied to each port.
+Different addons can be applied to different ports.
+Each addon decides whether to apply itself to each port, based
+on any characteristic it can determine about that module, and it
+can read all the keys, and all accessible EEPROM to decide.
+
 NOTE:  A possible future use of addons is to provide different
 or added keys to match different spec versions with different
 modules.  The base OOM keys might match 'rev 3' of 'the spec'.  An

--- a/oom/decode.py
+++ b/oom/decode.py
@@ -101,8 +101,8 @@ def get_signed_current(x):  # return in mA
 
 def get_string(x):  # copy the cbuffer into a string
     result = ''
-    for i in range(0, len(x)):
-        result += x[i]
+    for c in x:
+        result += c
     return result
 
 

--- a/oom/makefile
+++ b/oom/makefile
@@ -17,8 +17,6 @@ all: $(SRC) $(OBJ)
 	cp MUQ1BZB_EEPROM_20160108_192514.txt module_data/2.A0
 	cp MUQ1BZB_FCCABY_20160108_192514.txt module_data/2.pages
 	cp qsfpdatafile.txt module_data/5.A0
-	
-
 
 oomsouth_driver.exe: oomsouth_driver.c oom_internal.o oom_south.o \
 	             ./lib/oom_south.so makefile

--- a/oom/makefile
+++ b/oom/makefile
@@ -19,14 +19,20 @@ all: $(SRC) $(OBJ)
 	cp qsfpdatafile.txt module_data/5.A0
 	
 
-oomsouth_driver.exe: oomsouth_driver.c ./lib/oom_south.so makefile
-	gcc -Wall -c oomsouth_driver.c
-	gcc oomsouth_driver.o oom_south.o -o oomsouth_driver.exe
 
-./lib/oom_south.so: oom_south.c oom_south.h makefile
+oomsouth_driver.exe: oomsouth_driver.c oom_internal.o oom_south.o \
+	             ./lib/oom_south.so makefile
+	gcc -Wall -c oomsouth_driver.c
+	gcc oomsouth_driver.o oom_internal.o oom_south.o -o oomsouth_driver.exe
+
+oom_internal.o: oom_internal.c oom_internal.h
+	gcc -Wall -fPIC -c oom_internal.c
+
+./lib/oom_south.so: oom_south.c oom_internal.o oom_south.h \
+	            makefile
 	mkdir -p ./lib
 	gcc -Wall -fPIC -c oom_south.c
-	gcc -shared oom_south.o -o ./lib/oom_south.so
+	gcc -shared oom_internal.o oom_south.o -o ./lib/oom_south.so
 
 clean:
-	rm -rf oom_south.o ./lib/oom_south.so oomsouth_driver.exe module_data/*
+	rm -f oom_*.o ./lib/oom_south.so oomsouth_driver.exe module_data/*

--- a/oom/makefile
+++ b/oom/makefile
@@ -1,6 +1,10 @@
 # make the C southbound library, organize the pieces
 
-SRC = oom_south.h oom_south.c oomsouth_driver.c makefile sfp.py qsfp_plus.py \
+# Select a shim
+SHIM=file
+#SHIM=ethtool
+
+SRC = oom_south.h oom_$(SHIM).c oomsouth_driver.c makefile sfp.py qsfp_plus.py \
       oomdemo.py decode.py oomlib.py \
       MUP0WB0_EEPROM_20160108_192637.txt \
       MUP0WB0_FCCABY_20160108_192637.txt \
@@ -18,19 +22,19 @@ all: $(SRC) $(OBJ)
 	cp MUQ1BZB_FCCABY_20160108_192514.txt module_data/2.pages
 	cp qsfpdatafile.txt module_data/5.A0
 
-oomsouth_driver.exe: oomsouth_driver.c oom_internal.o oom_south.o \
+oomsouth_driver.exe: oomsouth_driver.c oom_internal.o oom_$(SHIM).o \
 	             ./lib/oom_south.so makefile
 	gcc -Wall -c oomsouth_driver.c
-	gcc oomsouth_driver.o oom_internal.o oom_south.o -o oomsouth_driver.exe
+	gcc oomsouth_driver.o oom_internal.o oom_$(SHIM).o -o oomsouth_driver.exe
 
 oom_internal.o: oom_internal.c oom_internal.h
 	gcc -Wall -fPIC -c oom_internal.c
 
-./lib/oom_south.so: oom_south.c oom_internal.o oom_south.h \
+./lib/oom_south.so: oom_$(SHIM).c oom_internal.o oom_south.h \
 	            makefile
 	mkdir -p ./lib
-	gcc -Wall -fPIC -c oom_south.c
-	gcc -shared oom_internal.o oom_south.o -o ./lib/oom_south.so
+	gcc -Wall -fPIC -c oom_$(SHIM).c
+	gcc -shared oom_internal.o oom_$(SHIM).o -o ./lib/oom_south.so
 
 clean:
 	rm -f oom_*.o ./lib/oom_south.so oomsouth_driver.exe module_data/*

--- a/oom/oom.py
+++ b/oom/oom.py
@@ -68,6 +68,10 @@ def oom_get_memory(port, function):
 
     funcmap = port.fmap
     retval = {}
+
+    if function not in funcmap:
+        return None
+
     for keys in funcmap[function]:
         retval[keys] = oom_get_keyvalue(port, keys)
     return retval

--- a/oom/oom_ethtool.c
+++ b/oom/oom_ethtool.c
@@ -1,0 +1,319 @@
+/*
+ * OOM Ethtool
+ *
+ * Copyright (c) 2016 Cumulus Networks, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/sockios.h>
+#include <linux/ethtool.h>
+#include <arpa/inet.h>
+
+#include "oom_south.h"
+
+#define MAX_PORTS 512
+
+#define SFF_A0_BASE 0x0
+#define SFF_A2_BASE 0x100
+#define SFF_ID_ADDR (SFF_A0_BASE + 0x0)
+#define SFF_ID_LEN  1
+
+#define ERROR(...) \
+        do { fprintf(oe->logfile ? oe->logfile : stderr, __VA_ARGS__); \
+             fflush(oe->logfile); \
+        } while(0)
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*x))
+
+typedef struct {
+        oom_port_t portlist[MAX_PORTS];
+        int portcount;
+        FILE *logfile;
+} oom_ethtool_t;
+
+oom_ethtool_t oom_ethtool;
+oom_ethtool_t *oe = &oom_ethtool;
+
+int ethtool_get_socket(void)
+{
+        int fd;
+
+        fd = socket(AF_INET, SOCK_DGRAM, 0);
+        if (fd < 0) {
+                ERROR("oom_ethtool: failed to open socket: %s", strerror(errno));
+                return -1;
+        }
+
+        return fd;
+}
+
+int ethtool_get_port(int fd, const char *ifname, oom_port_t *port)
+{
+        struct ethtool_modinfo modinfo = { .cmd = ETHTOOL_GMODULEINFO };
+        struct ifreq ifreq = { .ifr_data = (char *)&modinfo };
+        unsigned int ifindex;
+        int err;
+
+        ifindex = if_nametoindex(ifname);
+        if (ifindex == 0) {
+                return -ENODEV;
+        }
+
+        strncpy(ifreq.ifr_name, ifname, sizeof(ifreq.ifr_name));
+
+        err = ioctl(fd, SIOCETHTOOL, &ifreq);
+        if (err) {
+                return -EINVAL;
+        }
+
+
+        if (modinfo.type == 0) {
+                // No module
+                return -ENODEV;
+        }
+
+        if (port) {
+                port->oom_class = OOM_PORT_CLASS_SFF;
+                port->handle = (void *)(uintptr_t)ifindex;
+                strncpy(port->name, ifname, sizeof port->name);
+        }
+
+        return 0;
+}
+
+int ethtool_update_portlist(int fd)
+{
+        int count = 0;
+        int rv = 0;
+        DIR *dir;
+        struct dirent *dent;
+
+        dir = opendir("/sys/class/net");
+        if (dir < 0) {
+                ERROR("oom_ethtool: failed to open /sys/class/net\n");
+                return -EINVAL;
+        }
+
+        while ((dent = readdir(dir)) != NULL) {
+                oom_port_t port = { 0 };
+
+                if (strlen(dent->d_name) <= 0 || dent->d_name[0] == '.') {
+                        continue;
+                }
+
+                // skip ports that fail an ethtool ifreq for module information
+                if (ethtool_get_port(fd, dent->d_name, &port) != 0) {
+                        continue;
+                }
+
+                if (count < ARRAY_SIZE(oe->portlist)) {
+                        memcpy(&oe->portlist[count], &port, sizeof port);
+                } else {
+                        ERROR("oom_ethtool: internal portlist too small\n");
+                        rv = -ENOMEM;
+                        goto done;
+                }
+
+                count++;
+        }
+
+        oe->portcount = count;
+
+done:
+        closedir(dir);
+
+        if (rv < 0) {
+                memset(oe->portlist, 0, sizeof oe->portlist);
+                oe->portcount = 0;
+        }
+        return rv;
+}
+
+/*
+ * oom_get_portlist - get a list of ports
+ *
+ * Assumes portlist is oom_maxports() long.
+ *
+ * Returns the number of ports in the list or -1 on failure.
+ */
+int oom_get_portlist(oom_port_t portlist[], int listsize)
+{
+        bool changed = false;
+        int err;
+        int fd;
+
+#ifdef DEBUG_LOGFILE
+        oe->logfile = fopen("/tmp/oom_ethtool.log", "w");
+#endif
+
+        fd = ethtool_get_socket();
+        if (fd < 0) {
+                return -EINVAL;
+        }
+
+        err = ethtool_update_portlist(fd);
+        close(fd);
+        if (err < 0) {
+                ERROR("oom_ethtool: failed to update portlist\n");
+                return -EINVAL;
+        }
+
+        if (portlist == NULL) {
+                return oe->portcount;
+        }
+
+        // return -ENOMEM when the portlist provided is too small
+        if (oe->portcount > listsize) {
+                return -ENOMEM;
+        }
+
+        // detect changes to the provided portlist
+        if (memcmp(portlist, oe->portlist,
+                   oe->portcount * sizeof portlist[0]) != 0) {
+                changed = true;
+        }
+        memcpy(portlist, oe->portlist, oe->portcount * sizeof portlist[0]);
+
+        // if the portlist changed in size or content, return the count
+        if (changed || oe->portcount != listsize) {
+                return oe->portcount;
+        }
+
+        // return 0 if the input portlist matched the updated portlist
+        return 0;
+}
+
+int ethtool_get_memory(int fd, const char *ifname, int offset, int len, uint8_t *data)
+{
+        struct {
+                struct ethtool_eeprom eepromreq;
+                union {
+                        uint8_t buf[1024];
+                };
+        } eeprom = { .eepromreq.cmd = ETHTOOL_GMODULEEEPROM };
+        struct ifreq ifreq = { .ifr_data = (char *)&eeprom };
+        int err;
+
+        if (len > sizeof eeprom.buf) {
+                ERROR("oom_ethtool: request too large: %u\n", len);
+                return -1;
+        }
+
+        eeprom.eepromreq.offset = offset;
+        eeprom.eepromreq.len = len;
+
+        strncpy(ifreq.ifr_name, ifname, sizeof(ifreq.ifr_name));
+        err = ioctl(fd, SIOCETHTOOL, &ifreq);
+        if (err) {
+                ERROR("oom_ethtool: %u ifreq failed: 0x%x\n", ifreq.ifr_ifindex, err);
+                return err;
+        }
+
+        memcpy(data, eeprom.buf, len);
+
+        return 0;
+}
+
+int oom_get_memory_sff(oom_port_t* port, int address, int page, int offset,
+                       int len, uint8_t* data)
+
+{
+        char ifname[IF_NAMESIZE];
+        unsigned int ifindex;
+        int ethtool_offset;
+        int ethtool_len;
+        int fd;
+        int err;
+
+        ifindex = (unsigned int)(uintptr_t)port->handle;
+
+        if (!if_indextoname(ifindex, ifname)) {
+                ERROR("oom_ethtool: failed to translate index to name: %d\n", ifindex);
+                return -ENODEV;
+        }
+
+        if (strcmp(ifname, port->name) != 0) {
+                ERROR("oom_ethtool: port name for ifindex %d changed from %s to %s\n",
+                      ifindex, port->name, ifname);
+                return -ESTALE;
+        }
+
+        if (address == 0xa0) {
+                ethtool_offset = SFF_A0_BASE;
+        } else if (address == 0xa2) {
+                ethtool_offset = SFF_A2_BASE;
+        } else {
+                ERROR("oom_ethtool: invalid address: 0x%02x\n", address);
+                return -1;
+        }
+        ethtool_offset += page * 128;
+        ethtool_offset += offset;
+        ethtool_len = len;
+
+        fd = ethtool_get_socket();
+        if (fd < 0) {
+                return -EINVAL;
+        }
+
+        err = ethtool_get_memory(fd, ifname, ethtool_offset, ethtool_len, data);
+        close(fd);
+        return err;
+}
+
+int oom_set_memory_sff(oom_port_t* port, int address, int page, int offset,
+                       int len, uint8_t* data)
+
+{
+        // XXX - not implemented
+        return -1;
+}
+
+int oom_set_function(oom_port_t* port, oom_functions_t function, int value)
+{
+        // XXX - not implemented
+        return -1;
+}
+
+int oom_get_function(oom_port_t* port, oom_functions_t function, int* rv)
+{
+        // XXX - not implemented
+        return -1;
+}
+
+int oom_set_memory_cfp(oom_port_t* port, int address, int len, uint16_t* data)
+{
+        // XXX - not implemented
+        return -1;
+}
+
+int oom_get_memory_cfp(oom_port_t* port, int address, int len, uint16_t* data)
+{
+        // XXX - not implemented
+        return -1;
+}

--- a/oom/oom_file.c
+++ b/oom/oom_file.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "oom_south.h"
+#include "oom_internal.h"
 
 #define MAXPORTS 6
 
@@ -317,28 +318,6 @@ int readpage(FILE* fp, uint8_t* buf)
 		retval = fgets(inbuf, 80, fp);
 	}
 	return(0);
-}
-
-void print_block_hex(uint8_t* buf)
-{
-	int j, k;
-	uint8_t* bufptr8;
-	uint32_t tempintchar;
-
-	bufptr8 = buf;
-	for (j = 0; j < 8; j++) {
-		printf("       " );
-		for (k = 0; k < 19; k++) {
-			if ((k % 5) == 4) {
-				printf(" ");
-			} else {
-				tempintchar = *bufptr8;
-				printf("%.2X", tempintchar);
-				bufptr8++;
-			}
-		}
-		printf("\n");
-	}
 }
 
 /* intercept memcpy, print out parameters (uncomment the printf) */

--- a/oom/oom_internal.c
+++ b/oom/oom_internal.c
@@ -1,0 +1,28 @@
+/*
+ * Internal OOM functions
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+void print_block_hex(uint8_t* buf)
+{
+	int j, k;
+	uint8_t* bufptr8;
+	uint32_t tempintchar;
+
+	bufptr8 = buf;
+	for (j = 0; j < 8; j++) {
+		printf("       " );
+		for (k = 0; k < 19; k++) {
+			if ((k % 5) == 4) {
+				printf(" ");
+			} else {
+				tempintchar = *bufptr8;
+				printf("%.2X", tempintchar);
+				bufptr8++;
+			}
+		}
+		printf("\n");
+	}
+}

--- a/oom/oom_internal.h
+++ b/oom/oom_internal.h
@@ -1,0 +1,6 @@
+#ifndef OOM_INTERNAL_H_
+#define OOM_INTERNAL_H_
+
+extern void print_block_hex(uint8_t* buf);
+
+#endif

--- a/oom/oomcollectd.py
+++ b/oom/oomcollectd.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+
+# oomcollectd.py --
+#
+# Copyright (c) 2016 Cumulus Networks, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to
+# do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import oom
+import collectd
+
+class OOMValue(collectd.Values):
+    def __init__(self, dtype, port, key, value):
+        nkey = '%s-%s' % (key, port.port_name)
+        collectd.Values.__init__(self, type=dtype, type_instance=nkey,
+                                 values=[ value ])
+
+class LaserBiasCurrent(OOMValue):
+    def __init__(self, port, key, value):
+        OOMValue.__init__(self, 'current', port, key, value)
+
+class ReceivePower(OOMValue):
+    def __init__(self, port, key, value):
+        OOMValue.__init__(self, 'power', port, key, value)
+
+class LaserOutputPower(OOMValue):
+    def __init__(self, port, key, value):
+        OOMValue.__init__(self, 'power', port, key, value)
+
+class SupplyVoltage(OOMValue):
+    def __init__(self, port, key, value):
+        OOMValue.__init__(self, 'voltage', port, key, value)
+
+class ModuleTemperature(OOMValue):
+    def __init__(self, port, key, value):
+        OOMValue.__init__(self, 'temperature', port, key, value)
+
+def read_callback(data=None):
+    portlist = oom.oom_get_portlist()
+    for port in portlist:
+        dom = oom.oom_get_memory(port, 'DOM')
+        if dom is None:
+            continue
+
+        for key in ('TX1_POWER', 'TX2_POWER', 'TX3_POWER', 'TX4_POWER',
+                    'RX1_POWER', 'RX2_POWER', 'RX3_POWER', 'RX4_POWER'):
+            if key in dom:
+                value = dom[key] / 1000.0
+                LaserOutputPower(port, key[:3].lower(), value).dispatch()
+
+        for key in ('TX1_BIAS' , 'TX2_BIAS' , 'TX3_BIAS' , 'TX4_BIAS' ):
+            if key in dom:
+                value = dom[key] / 1000.0
+                LaserBiasCurrent(port, key[:3].lower(), value).dispatch()
+
+        if 'SUPPLY_VOLTAGE' in dom:
+            SupplyVoltage(port, 'supply', dom['SUPPLY_VOLTAGE']).dispatch()
+
+        if 'TEMPERATURE' in dom:
+            ModuleTemperature(port, 'module', dom['TEMPERATURE']).dispatch()
+
+collectd.register_read(read_callback)

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -142,9 +142,7 @@ class Port:
         self.c_port = cport
 
         # copy the C character array into a more manageable python string
-        self.port_name = ''
-        for i in range(32):
-            self.port_name += chr(cport.name[i])
+        self.port_name = bytearray(cport.name).rstrip('\0')
         self.port_type = get_port_type(self)
 
         # initialize the key maps, potentially unique for each port

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -71,7 +71,7 @@ port_type_e = {
     'NOT_PRESENT': -2,
     }
 
-# Southbound API will report the 'class' of a module, basically 
+# Southbound API will report the 'class' of a module, basically
 # whether it uses i2c addresses, pages, and bytes (SFF) or
 # it uses mdio, a flat 16 bit address space, and words (CFP)
 port_class_e = {
@@ -101,12 +101,12 @@ for name in modnamelist:
     name = name.split('/')[2]
     name = name[0:len(name)-3]
     modulist.append(name)
-modnamelist = glob.glob('./addons/*.pyc') # obfuscated modules!
+modnamelist = glob.glob('./addons/*.pyc')  # obfuscated modules!
 for name in modnamelist:
     name = name.split('/')[2]
     name = name[0:len(name)-4]
     modulist.append(name)
-modulist = list(set(modulist)) # eliminate dups, eg: x.py and x.pyc
+modulist = list(set(modulist))  # eliminate dups, eg: x.py and x.pyc
 
 for module in modulist:
     try:
@@ -121,6 +121,7 @@ for module in modulist:
             # skip that one ('add_features' is not there?)
             pass
 sys.path = sys.path[1:]  # put the search path back
+
 
 #
 # This class recreates the port structure in the southbound API
@@ -234,7 +235,6 @@ def oom_set_keyvalue(port, key, value):
     retval = oom_set_memory_sff(port, mm[key][1], mm[key][2], mm[key][3],
                                 mm[key][4], temp)
     return retval
-
 
 
 # debug helper function, print raw data, in hex

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -178,6 +178,11 @@ def oom_get_port(n):
 #
 def oom_get_portlist():
     numports = oomsouth.oom_get_portlist(0, 0)
+    if numports < 0:
+        raise RuntimeError("oom_get_portlist error: %d" % numports)
+    elif numports == 0:
+        return list()
+
     cport_array = c_port_t * numports
     cport_list = cport_array()
     retval = oomsouth.oom_get_portlist(cport_list, numports)

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -12,6 +12,7 @@
 #
 # ////////////////////////////////////////////////////////////////////
 
+import os
 import struct
 from ctypes import *
 import importlib
@@ -85,7 +86,8 @@ port_class_e = {
 # note this means the southbound shim MUST be installed in
 # this location (relative to this module, in lib, named oom_south.so)
 #
-oomsouth = cdll.LoadLibrary("./lib/oom_south.so")
+libdir = os.path.dirname(os.path.realpath(__file__))
+oomsouth = cdll.LoadLibrary(libdir + "/lib/oom_south.so")
 
 # one time setup, get the names of the decoders in the decode library
 decodelib = importlib.import_module('decode')

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -35,7 +35,7 @@ decodelib = importlib.import_module('decode')
 # and find any addons that should be incorporated
 modulist = glob.glob('./addons/*.py')
 addon_fns = []
-sys.path.insert(0,'./addons')   # required, to get them imported
+sys.path.insert(0, './addons')   # required, to get them imported
 for i in range(len(modulist)):
     modulist[i] = modulist[i].split('/')[2]
     modulist[i] = modulist[i][0:len(modulist[i])-3]

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -12,15 +12,73 @@
 #
 # ////////////////////////////////////////////////////////////////////
 
-import sfp
-import qsfp_plus
-import decode
-
 import struct
 from ctypes import *
 import importlib
 import glob
 import sys
+
+
+#
+# Mapping of port_type numbers to user accessible names
+# This is a copy of a matching table in oom_south.h
+# Might be a problem keeping these in sync, but
+# these mappings are based on the relevant standards,
+# so they should be fairly stable
+#
+port_type_e = {
+    'UNKNOWN': 0x00,
+    'GBIC': 0x01,
+    'SOLDERED': 0x02,
+    'SFP': 0x03,
+    'XBI': 0x04,
+    'XENPAK': 0x05,
+    'XFP': 0x06,
+    'XFF': 0x07,
+    'XFP_E': 0x08,
+    'XPAK': 0x09,
+    'X2': 0x0A,
+    'DWDM_SFP': 0x0B,
+    'QSFP': 0x0C,
+    'QSFP_PLUS': 0x0D,
+    'CXP': 0x0E,
+    'SMM_HD_4X': 0x0F,
+    'SMM_HD_8X': 0x10,
+    'QSFP28': 0x11,
+    'CXP2': 0x12,
+    'CDFP': 0x13,
+    'SMM_HD_4X_FANOUT': 0x14,
+    'SMM_HD_8X_FANOUT': 0x15,
+    'CDFP_STYLE_3': 0x16,
+    'MICRO_QSFP': 0x17,
+
+    #  next values are CFP types. Note that their spec
+    #  (CFP MSA Management Interface Specification ver 2.4 r06b page 67)
+    #  values overlap with the values for i2c type devices.  OOM has
+    #  chosen to add 256 (0x100) to the values to make them unique
+
+    'CFP': 0x10E,
+    '168_PIN_5X7': 0x110,
+    'CFP2': 0x111,
+    'CFP4': 0x112,
+    '168_PIN_4X5': 0x113,
+    'CFP2_ACO': 0x114,
+
+    #  special values to indicate that no module is in this port,
+    #  as well as invalid type
+
+    'INVALID': -1,
+    'NOT_PRESENT': -2,
+    }
+
+# Southbound API will report the 'class' of a module, basically 
+# whether it uses i2c addresses, pages, and bytes (SFF) or
+# it uses mdio, a flat 16 bit address space, and words (CFP)
+port_class_e = {
+    'UNKNOWN': 0x00,
+    'SFF': 0x01,
+    'CFP': 0x02
+    }
 
 #
 # link in the southbound shim
@@ -33,15 +91,27 @@ oomsouth = cdll.LoadLibrary("./lib/oom_south.so")
 decodelib = importlib.import_module('decode')
 
 # and find any addons that should be incorporated
-modulist = glob.glob('./addons/*.py')
 addon_fns = []
 sys.path.insert(0, './addons')   # required, to get them imported
-for i in range(len(modulist)):
-    modulist[i] = modulist[i].split('/')[2]
-    modulist[i] = modulist[i][0:len(modulist[i])-3]
+
+# build a list of modules in the addons directory
+modulist = []
+modnamelist = glob.glob('./addons/*.py')
+for name in modnamelist:
+    name = name.split('/')[2]
+    name = name[0:len(name)-3]
+    modulist.append(name)
+modnamelist = glob.glob('./addons/*.pyc') # obfuscated modules!
+for name in modnamelist:
+    name = name.split('/')[2]
+    name = name[0:len(name)-4]
+    modulist.append(name)
+modulist = list(set(modulist)) # eliminate dups, eg: x.py and x.pyc
+
+for module in modulist:
     try:
-        addlib = importlib.import_module(modulist[i])
-    except ImportError:
+        addlib = importlib.import_module(module)
+    except:
         # skip that one (it is not a module?)
         pass
     else:
@@ -51,13 +121,6 @@ for i in range(len(modulist)):
             # skip that one ('add_features' is not there?)
             pass
 sys.path = sys.path[1:]  # put the search path back
-
-port_class_e = {
-    'UNKNOWN': 0x00,
-    'SFF': 0x01,
-    'CFP': 0x02
-    }
-
 
 #
 # This class recreates the port structure in the southbound API
@@ -71,25 +134,19 @@ class c_port_t(Structure):
 # This class is the python port, which includes the C definition
 # of a port, plus other useful things, including the port type,
 # and the keymap for that port.
-class port:
-    def __init__(self):
-        self.ptype = 3   # hack, make this an SFP port for now
+class Port:
+    def __init__(self, cport):
+        print 'Initializing port: ' + str(cport.handle)
+        self.c_port = cport
 
-    # c_port is the c_port_t data structure returned
-    # by the southbound API
-    def add_c_port(self, c_port):
-        self.c_port = c_port
+        # copy the C character array into a more manageable python string
         self.port_name = ''
         for i in range(32):
-            self.port_name += chr(c_port.name[i])
-
-    def add_port_type(self, port_type):
-        self.port_type = port_type
+            self.port_name += chr(cport.name[i])
+        self.port_type = get_port_type(self)
 
         # initialize the key maps, potentially unique for each port
-        for tname, ptype in port_type_e.iteritems():
-            if ptype == port_type:
-                typename = tname.lower()
+        typename = type_to_str(self.port_type).lower()
         try:
             maps = importlib.import_module(typename, package=None)
             self.mmap = maps.MM
@@ -123,13 +180,7 @@ def oom_get_portlist():
     cport_array = c_port_t * numports
     cport_list = cport_array()
     retval = oomsouth.oom_get_portlist(cport_list, numports)
-    portcount = 0
-    portlist = [port() for cport in cport_list]
-    for cport in cport_list:
-        portlist[portcount].add_c_port(cport)
-        ptype = get_port_type(portlist[portcount])
-        portlist[portcount].add_port_type(ptype)
-        portcount += 1
+    portlist = [Port(cport) for cport in cport_list]
     return portlist
 
 
@@ -185,60 +236,8 @@ def oom_set_keyvalue(port, key, value):
     return retval
 
 
-#
-# Mapping of port_type numbers to user accessible names
-# This is a copy of a matching table in oom_south.h
-# Might be a problem keeping these in sync, but
-# these mappings are based on the relevant standards,
-# so they should be fairly stable
-#
-port_type_e = {
-    'UNKNOWN': 0x00,
-    'GBIC': 0x01,
-    'SOLDERED': 0x02,
-    'SFP': 0x03,
-    'XBI': 0x04,
-    'XENPAK': 0x05,
-    'XFP': 0x06,
-    'XFF': 0x07,
-    'XFP_E': 0x08,
-    'XPAK': 0x09,
-    'X2': 0x0A,
-    'DWDM_SFP': 0x0B,
-    'QSFP': 0x0C,
-    'QSFP_PLUS': 0x0D,
-    'CXP': 0x0E,
-    'SMM_HD_4X': 0x0F,
-    'SMM_HD_8X': 0x10,
-    'QSFP28': 0x11,
-    'CXP2': 0x12,
-    'CDFP': 0x13,
-    'SMM_HD_4X_FANOUT': 0x14,
-    'SMM_HD_8X_FANOUT': 0x15,
-    'CDFP_STYLE_3': 0x16,
-    'MICRO_QSFP': 0x17,
 
-    #  next values are CFP types. Note that their spec
-    #  (CFP MSA Management Interface Specification ver 2.4 r06b page 67)
-    #  values overlap with the values for i2c type devices.  OOM has
-    #  chosen to add 256 (0x100) to the values to make them unique
-
-    'CFP': 0x10E,
-    '168_PIN_5X7': 0x110,
-    'CFP2': 0x111,
-    'CFP4': 0x112,
-    '168_PIN_4X5': 0x113,
-    'CFP2_ACO': 0x114,
-
-    #  special values to indicate that no module is in this port,
-    #  as well as invalid type
-
-    'INVALID': -1,
-    'NOT_PRESENT': -2,
-    }
-
-
-# helper function, print raw data, in hex
+# debug helper function, print raw data, in hex
 def print_block_hex(data):
     dataptr = 0
     bytesleft = len(data)
@@ -264,10 +263,9 @@ def print_block_hex(data):
         print outstr
 
 
-# set or clear a bit, for writing one bit back to EEPROM
-def set_bit(value, bit):
-    return (value | (1 << bit))
-
-
-def clear_bit(value, bit):
-    return (value & ~(1 << bit))
+# helper routine to return module type as string (reverse port_type_e)
+def type_to_str(modtype):
+    for tname, mtype in port_type_e.iteritems():
+        if mtype == modtype:
+            return tname
+    return ''

--- a/oom/oomlib.py
+++ b/oom/oomlib.py
@@ -136,7 +136,6 @@ class c_port_t(Structure):
 # and the keymap for that port.
 class Port:
     def __init__(self, cport):
-        print 'Initializing port: ' + str(cport.handle)
         self.c_port = cport
 
         # copy the C character array into a more manageable python string
@@ -148,6 +147,7 @@ class Port:
         # initialize the key maps, potentially unique for each port
         typename = type_to_str(self.port_type).lower()
         try:
+            # here is where the type is tied to the keymap file
             maps = importlib.import_module(typename, package=None)
             self.mmap = maps.MM
             self.fmap = maps.FM

--- a/oom/oomsouth_driver.c
+++ b/oom/oomsouth_driver.c
@@ -4,8 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "oom_south.h"
-
-extern void print_block_hex(uint8_t* buf);
+#include "oom_internal.h"
 
 int main() {
 	


### PR DESCRIPTION
Hi Don,

Here's a minimal set of changes to build oom on Linux (with a little cleanup along the way).  I'm not sure if it's working as intended.  Does this look right to you?

```
dustin@magnum:~/git/oom/oom$ ./oomsouth_driver.exe 
Max Ports: 6
module 1 is not present (./module_data/1.A0)
module 3 is not present (./module_data/3.A0)
module 4 is not present (./module_data/4.A0)
�j� is not a module data file(4)
./module_data/5.A0 is not a module data file(2)
returned from get_portlis, errno = 0
 Port handle  oom_class   port name
     0           1         port0
     1           0         port1
     2           1         port2
     3           2         port3
     4           0         port4
     5           0         port5
mockdata (addr): 0x1d26cf0, retdata (addr): 0x1d26d80
1st and last bytes (should be 0, 127): 0, 127
mockdata16 (addr): 0x1d26e10, retdata16 (addr): 0x1d27020
SET16: Port: 3, address: 0x8A00, len: 256
GET16: Port: 3, address: 0x8A01, len: 255
1st, last bytes (1001, 1255): 1001, 1255
```

In any case, it would be great if you could try this out to make sure I didn't break anything.  Thanks.
