### PR TITLE
Refactor Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 *.stackdump
 lib
 module_data
+stamps
 /dist/
 /*.egg-info

--- a/oom/makefile
+++ b/oom/makefile
@@ -1,57 +1,142 @@
-# make the C southbound library, organize the pieces
+#-------------------------------------------------------------------------------
+#>
+#
+# Copyright (C) 2015-2016 Don Bollinger <don@thebollingers.org>
+# Copyright (C) 2016 Carlos Cardenas <carlos@cumulusnetworks.com>
+#
+# SPDX-License-Identifier:     MIT
+#
+# Builds the Common Module Interface library
+#
+#<
 
-# Select a shim
-SHIM=file
-# SHIM=ethtool
-# SHIM=aardvark
+# Don't move this, it must be in FRONT of any included makefiles
+THIS_MAKEFILE = $(realpath $(firstword $(MAKEFILE_LIST)))
 
-SRC = oom_south.h oom_$(SHIM).c oomsouth_driver.c makefile \
-      MUP0WB0_EEPROM_20160108_192637.txt \
-      MUP0WB0_FCCABY_20160108_192637.txt \
-      MUQ1BZB_EEPROM_20160108_192514.txt \
-      MUQ1BZB_FCCABY_20160108_192514.txt \
-      qsfpdatafile.txt\
-      qsfp28datafile.txt
+# Allow users to override any ?= variables early
+-include local.make
 
-OBJ = ./lib/oom_south.so oomsouth_driver.exe
+#-------------------------------------------------------------------------------
+#
+# Setup
+#
 
-all: $(SRC) $(OBJ)
-	mkdir -p module_data
-	cp MUP0WB0_EEPROM_20160108_192637.txt module_data/0.A0
-	cp MUP0WB0_FCCABY_20160108_192637.txt module_data/0.pages
-	cp MUQ1BZB_EEPROM_20160108_192514.txt module_data/2.A0
-	cp MUQ1BZB_FCCABY_20160108_192514.txt module_data/2.pages
-	cp qsfpdatafile.txt module_data/5.A0
-	cp qsfp28datafile.txt module_data/4.A0
+SHELL   = bash
+V ?= 0
+Q = @
+ifneq ($V,0)
+    Q =
+endif
 
-oomsouth_driver.exe: oomsouth_driver.c oom_internal.o oom_$(SHIM).o \
-	             ./lib/oom_south.so aardvark.c makefile
-	gcc -Wall -c oomsouth_driver.c
-	mkdir -p ./lib
+#-------------------------------------------------------------------------------
+#
+# help (the default target)
+#
+
+.SUFFIXES:
+
+PHONY += help
+help:
+	$(Q) sed -n -e "/^#>/,/^#</{s/^#[ <>]*//;s/\.PHONY *://;p}" $(THIS_MAKEFILE)
+	$(Q) echo ""
+	$(Q) echo "TARGETS"
+	$(Q) for I in $(sort $(PHONY)); do echo "    $$I"; done
+	$(Q) echo ""
+
+#-------------------------------------------------------------------------------
+#
+# local vars
+#
+
+LIBDIR      = $(abspath ./lib)
+STAMPDIR    = $(abspath ./stamps)
+MODULEDIR   = $(abspath ./module_data)
+
+PROJECT_STAMP = $(STAMPDIR)/stamp-project
+project-stamp: $(PROJECT_STAMP)
+$(PROJECT_STAMP):
+	$(Q) mkdir -pv $(LIBDIR) $(STAMPDIR) $(MODULEDIR)
+	$(Q) touch $@
+
+MOD_INTERNAL_STAMP = $(STAMPDIR)/internal-stamp
+MOD_SOUTH_STAMP    = $(STAMPDIR)/southbound-stamp
+MOD_DRIVER_STAMP   = $(STAMPDIR)/driver-stamp
+MOD_DATA_STAMP     = $(STAMPDIR)/data-stamp
+#-------------------------------------------------------------------------------
+#
+# vars -- Usually specified on command line
+#
+SHIM      ?= file
+
+# Verify shim type
+ifneq ($(filter-out file ethtool aardvark, $(SHIM)),)
+    $(warning Unsupported southbound interface: $(SHIM))
+    $(error Supported interfaces: file ethtool aardvark)
+endif
+
+
+#-------------------------------------------------------------------------------
+#
+# top level targets
+#
+
+PHONY += all library driver test-data clean
+
+all: library driver test-data
+	$(Q) echo "=== Finished making $@ ==="
+
+library: $(PROJECT_STAMP) $(MOD_INTERNAL_STAMP) $(MOD_SOUTH_STAMP)
+	$(Q) echo "=== Finished making $@ ==="
+
+$(MOD_INTERNAL_STAMP): oom_internal.c oom_internal.h
+	$(Q) rm -f $@
+	$(Q) echo "==== Compiling Internal Pieces ===="
+	$(Q) gcc -Wall -fPIC -c oom_internal.c
+	$(Q) touch $@
+
+$(MOD_SOUTH_STAMP): oom_south.h oom_$(SHIM).c
+	$(Q) rm -f $@
+	$(Q) echo "==== Compiling Library Shim: $(SHIM) ===="
+	$(Q) gcc -Wall -fPIC -c oom_$(SHIM).c
 ifeq ($(SHIM), aardvark)
-	gcc oomsouth_driver.o oom_internal.o oom_$(SHIM).o \
+		$(Q) cp -f aardvark.dll $(LIBDIR)
+		$(Q) gcc -Wall -c aardvark.c
+		$(Q) gcc -shared oom_internal.o aardvark.o oom_$(SHIM).o \
+				-o $(LIBDIR)/oom_south.so
+else
+		$(Q) gcc -shared oom_internal.o oom_$(SHIM).o -o $(LIBDIR)/oom_south.so
+endif
+	$(Q) touch $@
+
+driver: library $(MOD_DRIVER_STAMP)
+$(MOD_DRIVER_STAMP): oomsouth_driver.c
+	$(Q) rm -f $@
+	$(Q) echo "==== Compiling Driver Shim: $(SHIM) ===="
+	$(Q) gcc -Wall -c oomsouth_driver.c
+ifeq ($(SHIM), aardvark)
+	$(Q) gcc oomsouth_driver.o oom_internal.o oom_$(SHIM).o \
 		aardvark.o -o oomsouth_driver.exe
 else
-	gcc oomsouth_driver.o oom_internal.o oom_$(SHIM).o \
+	$(Q) gcc oomsouth_driver.o oom_internal.o oom_$(SHIM).o \
 		-o oomsouth_driver.exe
 endif
+	$(Q) touch $@
 
-oom_internal.o: oom_internal.c oom_internal.h
-	gcc -Wall -fPIC -c oom_internal.c
-
-./lib/oom_south.so: oom_$(SHIM).c oom_internal.o oom_south.h \
-	            makefile
-	gcc -Wall -fPIC -c oom_$(SHIM).c
-	mkdir -p ./lib
-ifeq ($(SHIM), aardvark)
-		cp -f aardvark.dll ./lib
-		gcc -Wall -c aardvark.c
-		gcc -shared oom_internal.o aardvark.o oom_$(SHIM).o \
-				-o ./lib/oom_south.so
-else
-		gcc -shared oom_internal.o oom_$(SHIM).o -o ./lib/oom_south.so
-endif
+test-data: $(MOD_DATA_STAMP)
+$(MOD_DATA_STAMP): $(PROJECT_STAMP)
+	$(Q) rm -f $@
+	$(Q) echo "==== Copying Module Data ===="
+	$(Q) cp MUP0WB0_EEPROM_20160108_192637.txt $(MODULEDIR)/0.A0
+	$(Q) cp MUP0WB0_FCCABY_20160108_192637.txt $(MODULEDIR)/0.pages
+	$(Q) cp MUQ1BZB_EEPROM_20160108_192514.txt $(MODULEDIR)/2.A0
+	$(Q) cp MUQ1BZB_FCCABY_20160108_192514.txt $(MODULEDIR)/2.pages
+	$(Q) cp qsfpdatafile.txt $(MODULEDIR)/5.A0
+	$(Q) cp qsfp28datafile.txt $(MODULEDIR)/4.A0
+	$(Q) touch $@
 
 clean:
-	rm -f oom_*.o ./lib/oom_south.so oomsouth_driver.exe module_data/* \
-		aardvark.o ./lib/aardvark.dll
+	$(Q) rm -rf $(MODULEDIR) $(LIBDIR) $(STAMPDIR)
+	$(Q) rm -f *.pyc *.o oomsouth_driver.exe
+	$(Q) echo "=== Finished making $@ ==="
+
+.PHONY: $(PHONY)


### PR DESCRIPTION
Refactor Makefile to be stamp based to eliminate chances
a shim library is different than the shim driver.

The refactor also includes the ability to declare the shim library
without having to modify the Makefile along with the ability to
declare a local.make file to overwrite various variables.

Examples of this is as follows:

```
los@ndnd:% make 
Copyright (C) 2015-2016 Don Bollinger <don@thebollingers.org>
Copyright (C) 2016 Carlos Cardenas <carlos@cumulusnetworks.com>

SPDX-License-Identifier:     MIT

Builds the Common Module Interface library

TARGETS
    all
    clean
    driver
    help
    library
    test-data
```

```
los@ndnd:% make SHIM=ethtool all
mkdir: created directory ‘/home/los/working/gh-private/oom/oom/lib’
mkdir: created directory ‘/home/los/working/gh-private/oom/oom/stamps’
mkdir: created directory ‘/home/los/working/gh-private/oom/oom/module_data’
==== Compiling Internal Pieces ====
==== Compiling Library Shim: ethtool ====
=== Finished making library ===
==== Compiling Driver Shim: ethtool ====
==== Copying Module Data ====
=== Finished making all ===
```
